### PR TITLE
disposed slideOutAnimation

### DIFF
--- a/lib/draggable_card.dart
+++ b/lib/draggable_card.dart
@@ -140,6 +140,7 @@ class _DraggableCardState extends State<DraggableCard>
 
   @override
   void dispose() {
+    slideOutAnimation.dispose();
     slideBackAnimation.dispose();
     super.dispose();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: swipe_cards
 description: Tinder like swipe cards.
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/AnupKumarPanwar/swipe_cards
 
 environment:


### PR DESCRIPTION
fixing error

`_draggablecardstate#f7d66(tickers: tracking 1 ticker) was disposed with an active ticker.
I/flutter (16505): _draggablecardstate created a ticker via its tickerproviderstatemixin, but at the time dispose() was called on the mixin, that ticker was still active. all tickers must be disposed before calling super.dispose().
I/flutter (16505): tickers used by animationcontrollers should be disposed by calling dispose() on the animationcontroller itself. otherwise, the ticker will leak.`